### PR TITLE
feat(version): accept pure-alphabet version segments

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -132,6 +132,33 @@ export function string2uint8array(str) {
   return array;
 }
 
+// compare two dotted version strings
+// allow a, aa, Aa … : if a part starts with a letter we treat it as `0`-prefixed
+// so 0a  < 0b  < 1   just like before, while aa < ab < ba < bb
+export function cmpVersion(a = '', b = '') {
+  const pa = a.split('.').filter(Boolean);
+  const pb = b.split('.').filter(Boolean);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
+    const ap = pa[i] ?? '0';
+    const bp = pb[i] ?? '0';
+    const na = parseInt(ap, 10);
+    const nb = parseInt(bp, 10);
+    const da = !Number.isNaN(na);
+    const db = !Number.isNaN(nb);
+    const sa = (da ? ap.slice(String(na).length) : ap).toLowerCase();
+    const sb = (db ? bp.slice(String(nb).length) : bp).toLowerCase();
+    if (da && db) {
+      if (na !== nb) return na > nb ? 1 : -1;
+      if (sa === sb) continue;
+      return sa > sb ? 1 : -1;
+    }
+    if (da !== db) return da ? 1 : -1;
+    if (sa === sb) continue;
+    return sa > sb ? 1 : -1;
+  }
+  return 0;
+}
+
 const VERSION_RE = /^(.*?)-([-.0-9a-z]+)|$/i;
 const DIGITS_RE = /^\d+$/; // using regexp to avoid +'1e2' being parsed as 100
 
@@ -163,7 +190,7 @@ function compareVersionChunk(ver1, ver2, isSemverMode) {
         ? a - b
         : a > b || a < b && -1;
     } else {
-      delta = (parseInt(a, 10) || 0) - (parseInt(b, 10) || 0);
+      delta = cmpVersion(a, b);
     }
   }
   return delta || isSemverMode && (len1 - len2);

--- a/test/unit/cmpVersion.test.js
+++ b/test/unit/cmpVersion.test.js
@@ -1,0 +1,12 @@
+import { cmpVersion } from '@/common/util';
+
+test('accepts alphabet-only parts', () => {
+  expect(cmpVersion('a',  'b')).toBeLessThan(0);
+  expect(cmpVersion('aa', 'ab')).toBeLessThan(0);
+  expect(cmpVersion('a.a', 'a.b')).toBeLessThan(0);
+});
+
+test('keeps numeric precedence', () => {
+  expect(cmpVersion('0a', 'a')).toBeGreaterThan(0);
+  expect(cmpVersion('1',  'a')).toBeGreaterThan(0);
+});

--- a/violentmonkey.github.io/api/metadata-block/index.md
+++ b/violentmonkey.github.io/api/metadata-block/index.md
@@ -1,0 +1,5 @@
+# Metadata Block
+
+## @version
+
+Each part can start with either digits **or** letters. Comparison is alphanumeric, case-insensitive.


### PR DESCRIPTION
## Summary
- relax version comparator to allow letter-only segments
- use new comparison in version sorting
- docs: note alphanumeric segments

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e25e80e6c8328a4de21403804ff73